### PR TITLE
This will update our test to use a custom jasmine matcher

### DIFF
--- a/dist/stubs/describe-shell-start.stub
+++ b/dist/stubs/describe-shell-start.stub
@@ -1,11 +1,16 @@
 import React from 'react';
 
+import ReactTestUtils from 'react-addons-test-utils';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 
 import <%= className %> from '<%= relativePath %>';
 import { render, shallow, mount } from '<%= relativeLibPath %>utils/enzyme/mounting.js';
+import matchers from '<%= relativeLibPath %>utils/matchers.js';
 
 injectTapEventPlugin();
 
 describe('<%= name %>', () => {
+    beforeEach(() => {
+        jasmine.addMatchers(matchers(ReactTestUtils));
+    });
     

--- a/dist/stubs/subcomponents.stub
+++ b/dist/stubs/subcomponents.stub
@@ -13,17 +13,16 @@
 
     it('should pass props down to subcomponents', () => {
         // Arrange
-        const expected = {};
+        const expectedProps = {};
         const wrapper = mount(<%= className %>);
 
         // Act
 
         // Assert
-        Object.keys(expected).map(name => {
-            const subComponent = wrapper.find(name).at(0);
+        Object.keys(expectedProps).map(subComponentName => {
+            const subComponent = wrapper.find(subComponentName).at(0);
+
             expect(subComponent.length).toBe(1);
-            Object.keys(expected[name]).map(prop =>
-                expect(subComponent.prop(prop))
-                    .toBe(expected[name][prop]));
+            expect(subComponent.props()).toContainSubset(expectedProps[subComponentName]);
         });
     });

--- a/src/stubs/describe-shell-start.stub
+++ b/src/stubs/describe-shell-start.stub
@@ -1,11 +1,16 @@
 import React from 'react';
 
+import ReactTestUtils from 'react-addons-test-utils';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 
 import <%= className %> from '<%= relativePath %>';
 import { render, shallow, mount } from '<%= relativeLibPath %>utils/enzyme/mounting.js';
+import matchers from '<%= relativeLibPath %>utils/matchers.js';
 
 injectTapEventPlugin();
 
 describe('<%= name %>', () => {
+    beforeEach(() => {
+        jasmine.addMatchers(matchers(ReactTestUtils));
+    });
     

--- a/src/stubs/subcomponents.stub
+++ b/src/stubs/subcomponents.stub
@@ -13,17 +13,16 @@
 
     it('should pass props down to subcomponents', () => {
         // Arrange
-        const expected = {};
+        const expectedProps = {};
         const wrapper = mount(<%= className %>);
 
         // Act
 
         // Assert
-        Object.keys(expected).map(name => {
-            const subComponent = wrapper.find(name).at(0);
+        Object.keys(expectedProps).map(subComponentName => {
+            const subComponent = wrapper.find(subComponentName).at(0);
+
             expect(subComponent.length).toBe(1);
-            Object.keys(expected[name]).map(prop =>
-                expect(subComponent.prop(prop))
-                    .toBe(expected[name][prop]));
+            expect(subComponent.props()).toContainSubset(expectedProps[subComponentName]);
         });
     });


### PR DESCRIPTION
- Added `ReactTestUtils` since it seemed to be missing on execution of generated spec file
- Importing our `matchers.js` file for custom matchers
- Upated test code to use Object comparison

Must push https://github.com/mb3online/jest-speck-plugin/pull/8 before this PR, since I have merge that PR into this one for testing.